### PR TITLE
feat: add React Firebase app skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+VITE_FIREBASE_API_KEY=your_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_auth_domain
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+VITE_FIREBASE_APP_ID=your_app_id

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# KWLBASE
+# KWL Web App
+
+関西ウイスキーラバーズ用の最小React + Firebaseアプリです。
+
+## セットアップ
+
+```bash
+npm install
+cp .env.example .env # Firebase設定を記入
+npm run dev
+```
+
+## 環境変数例
+`.env.example` を参照し、Firebaseの各種キーを設定してください。
+
+## Firebase ルール
+`firestore.rules` を参照してください。開発用として、認証済ユーザーのみ書き込み可・読み込みは誰でも可能です。
+
+## 画面
+- ログイン (Google/メール)
+- テイスティング投稿 (写真, 銘柄, 蒸留所, 樽種類, ABV, コメント)
+- 投稿一覧/検索 (最新順, ブランド/蒸留所フィルタ)
+- イベント一覧/登録 (タイトル, 日付, 詳細, 参加ボタン)
+
+Tailwind CSSで簡易UIを構築しています。

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read: if true; // anyone can read
+      allow write: if request.auth != null; // authenticated users can write
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KWL</title>
+  </head>
+  <body class="bg-gray-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "kwl-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1",
+    "firebase": "^10.8.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.8",
+    "@types/react-dom": "^18.2.4",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.10"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,37 @@
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { auth } from './firebase';
+
+// Components
+import Navbar from './components/Navbar';
+
+// Page components
+import Login from './pages/Login';
+import TastingForm from './pages/TastingForm';
+import Posts from './pages/Posts';
+import Events from './pages/Events';
+
+// Main application component with routing
+export default function App() {
+  const [user, setUser] = useState<User | null>(null);
+
+  // Listen for authentication changes
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, setUser);
+    return unsub;
+  }, []);
+
+  return (
+    <BrowserRouter>
+      <Navbar user={user} />
+      <Routes>
+        <Route path="/login" element={user ? <Navigate to="/posts" /> : <Login />} />
+        <Route path="/tasting" element={user ? <TastingForm /> : <Navigate to="/login" />} />
+        <Route path="/posts" element={user ? <Posts /> : <Navigate to="/login" />} />
+        <Route path="/events" element={user ? <Events /> : <Navigate to="/login" />} />
+        <Route path="*" element={<Navigate to={user ? '/posts' : '/login'} />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+import { auth } from '../firebase';
+import { signOut, User } from 'firebase/auth';
+
+interface Props {
+  user: User | null;
+}
+
+// Simple navigation bar used across pages
+export default function Navbar({ user }: Props) {
+  return (
+    <nav className="p-4 bg-white shadow flex gap-4">
+      <Link to="/posts" className="font-bold">KWL</Link>
+      {user && (
+        <>
+          <Link to="/tasting">テイスティング投稿</Link>
+          <Link to="/events">イベント</Link>
+          <button onClick={() => signOut(auth)} className="ml-auto text-sm text-red-500">ログアウト</button>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,21 @@
+// Firebase initialization
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+// Config values are loaded from Vite environment variables
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY as string,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN as string,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID as string,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET as string,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID as string,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID as string,
+};
+
+// Initialize core services for use across the app
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const firestore = getFirestore(app);
+export const storage = getStorage(app);

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+// Entry point for the React application
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { collection, query, orderBy, addDoc, onSnapshot, updateDoc, doc, arrayUnion, serverTimestamp } from 'firebase/firestore';
+import { auth, firestore } from '../firebase';
+
+interface Event {
+  id: string;
+  title: string;
+  date: string;
+  detail: string;
+  participants?: string[];
+}
+
+// Event list page with creation form and join button
+export default function Events() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+  const [detail, setDetail] = useState('');
+
+  useEffect(() => {
+    const q = query(collection(firestore, 'events'), orderBy('date', 'asc'));
+    const unsub = onSnapshot(q, snapshot => {
+      setEvents(snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as any) })));
+    });
+    return unsub;
+  }, []);
+
+  // Create a new event document
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await addDoc(collection(firestore, 'events'), {
+      title,
+      date,
+      detail,
+      participants: [],
+      createdAt: serverTimestamp(),
+    });
+    setTitle('');
+    setDate('');
+    setDetail('');
+  };
+
+  // Register current user to event
+  const handleJoin = async (id: string) => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    await updateDoc(doc(firestore, 'events', id), {
+      participants: arrayUnion(uid),
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">イベント</h1>
+      <form onSubmit={handleCreate} className="space-y-2 max-w-md mb-6">
+        <input className="border p-2 w-full" placeholder="タイトル" value={title} onChange={e => setTitle(e.target.value)} />
+        <input className="border p-2 w-full" type="date" value={date} onChange={e => setDate(e.target.value)} />
+        <textarea className="border p-2 w-full" placeholder="詳細" value={detail} onChange={e => setDetail(e.target.value)} />
+        <button type="submit" className="bg-green-500 text-white px-4 py-2">登録</button>
+      </form>
+      <div className="space-y-4">
+        {events.map(ev => (
+          <div key={ev.id} className="border p-4 bg-white">
+            <div className="font-bold">{ev.title}</div>
+            <div>{ev.date}</div>
+            <p className="mb-2">{ev.detail}</p>
+            <button onClick={() => handleJoin(ev.id)} className="bg-blue-500 text-white px-2 py-1">参加</button>
+            <div className="text-sm mt-1">参加者: {ev.participants?.length || 0}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { GoogleAuthProvider, signInWithPopup, signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebase';
+
+// Simple login page offering Google OAuth and email/password auth
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isNew, setIsNew] = useState(false);
+
+  // Handle email based sign-in or sign-up
+  const handleEmailAuth = async () => {
+    if (isNew) {
+      await createUserWithEmailAndPassword(auth, email, password);
+    } else {
+      await signInWithEmailAndPassword(auth, email, password);
+    }
+  };
+
+  // Popup Google login
+  const handleGoogle = async () => {
+    await signInWithPopup(auth, new GoogleAuthProvider());
+  };
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl mb-4">ログイン</h1>
+      <div className="mb-4">
+        <input className="border p-2 w-full mb-2" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="border p-2 w-full mb-2" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button onClick={handleEmailAuth} className="bg-blue-500 text-white px-4 py-2 w-full">{isNew ? '登録' : 'ログイン'}</button>
+        <button onClick={() => setIsNew(!isNew)} className="text-sm text-blue-500 mt-1 w-full">{isNew ? '既にアカウントを持っています' : '新規登録はこちら'}</button>
+      </div>
+      <button onClick={handleGoogle} className="border px-4 py-2 w-full">Googleでログイン</button>
+    </div>
+  );
+}

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { collection, query, orderBy, onSnapshot } from 'firebase/firestore';
+import { firestore } from '../firebase';
+
+interface Post {
+  id: string;
+  brand: string;
+  distillery: string;
+  caskType: string;
+  abv: string;
+  comment: string;
+  photoURL: string;
+}
+
+// Page listing tasting posts with simple brand/distillery filters
+export default function Posts() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [brandFilter, setBrandFilter] = useState('');
+  const [distilleryFilter, setDistilleryFilter] = useState('');
+
+  useEffect(() => {
+    const q = query(collection(firestore, 'tastings'), orderBy('createdAt', 'desc'));
+    const unsub = onSnapshot(q, snapshot => {
+      setPosts(snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as any) })));
+    });
+    return unsub;
+  }, []);
+
+  const filtered = posts.filter(p =>
+    p.brand.toLowerCase().includes(brandFilter.toLowerCase()) &&
+    p.distillery.toLowerCase().includes(distilleryFilter.toLowerCase())
+  );
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">投稿一覧</h1>
+      <div className="flex gap-2 mb-4">
+        <input className="border p-2" placeholder="ブランド" value={brandFilter} onChange={e => setBrandFilter(e.target.value)} />
+        <input className="border p-2" placeholder="蒸留所" value={distilleryFilter} onChange={e => setDistilleryFilter(e.target.value)} />
+      </div>
+      <div className="space-y-4">
+        {filtered.map(p => (
+          <div key={p.id} className="border p-4 bg-white">
+            {p.photoURL && <img src={p.photoURL} alt={p.brand} className="w-full mb-2" />}
+            <div className="font-bold">{p.brand}</div>
+            <div>{p.distillery} / {p.caskType} / {p.abv}%</div>
+            <p>{p.comment}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/TastingForm.tsx
+++ b/src/pages/TastingForm.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { firestore, storage, auth } from '../firebase';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+
+// Form for creating a tasting note with optional photo upload
+export default function TastingForm() {
+  const [brand, setBrand] = useState('');
+  const [distillery, setDistillery] = useState('');
+  const [caskType, setCaskType] = useState('');
+  const [abv, setAbv] = useState('');
+  const [comment, setComment] = useState('');
+  const [photo, setPhoto] = useState<File | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    let photoURL = '';
+    if (photo) {
+      const storageRef = ref(storage, `tastings/${Date.now()}_${photo.name}`);
+      await uploadBytes(storageRef, photo);
+      photoURL = await getDownloadURL(storageRef);
+    }
+    await addDoc(collection(firestore, 'tastings'), {
+      uid: auth.currentUser?.uid,
+      brand,
+      distillery,
+      caskType,
+      abv,
+      comment,
+      photoURL,
+      createdAt: serverTimestamp(),
+    });
+    setBrand('');
+    setDistillery('');
+    setCaskType('');
+    setAbv('');
+    setComment('');
+    setPhoto(null);
+    alert('投稿しました');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 max-w-md mx-auto space-y-2">
+      <h1 className="text-xl">テイスティング投稿</h1>
+      <input className="border p-2 w-full" placeholder="銘柄" value={brand} onChange={e => setBrand(e.target.value)} />
+      <input className="border p-2 w-full" placeholder="蒸留所" value={distillery} onChange={e => setDistillery(e.target.value)} />
+      <input className="border p-2 w-full" placeholder="樽種類" value={caskType} onChange={e => setCaskType(e.target.value)} />
+      <input className="border p-2 w-full" placeholder="ABV" value={abv} onChange={e => setAbv(e.target.value)} />
+      <textarea className="border p-2 w-full" placeholder="コメント" value={comment} onChange={e => setComment(e.target.value)} />
+      <input type="file" onChange={e => setPhoto(e.target.files?.[0] || null)} />
+      <button type="submit" className="bg-green-500 text-white px-4 py-2">投稿</button>
+    </form>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,4 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"]
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vite + React + Tailwind project with Firebase initialization
- implement login, tasting post, posts list with filters, and events pages
- add Firestore dev rules and setup documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa00cafc4832393131b7f101a168d